### PR TITLE
Handle missing currentMount

### DIFF
--- a/habitica/core/user.py
+++ b/habitica/core/user.py
@@ -244,7 +244,7 @@ class Inventory(base.ApiObject):
 		return self.content.petInfo(self._data['currentPet']) if self._data['currentPet'] else None
 	@property
 	def mount(self):
-		return self.content.mountInfo(self._data['currentMount']) if self._data['currentMount'] else None
+		return self.content.mountInfo(self._data['currentMount']) if self._data.get('currentMount') else None
 	@property
 	def eggs(self):
 		return self._data['eggs'] # FIXME is it a dict of IDs?


### PR DESCRIPTION
Resolves the following issue:
```
$ habitica status
---------------
Level 4 Warrior
---------------
Traceback (most recent call last):
  File "/opt/homebrew/bin/habitica", line 33, in <module>
    sys.exit(load_entry_point('habitica', 'console_scripts', 'habitica')())
  File "/opt/homebrew/lib/python3.10/site-packages/click-8.0.3-py3.10.egg/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/opt/homebrew/lib/python3.10/site-packages/click-8.0.3-py3.10.egg/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/opt/homebrew/lib/python3.10/site-packages/click-8.0.3-py3.10.egg/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/opt/homebrew/lib/python3.10/site-packages/click-8.0.3-py3.10.egg/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/opt/homebrew/lib/python3.10/site-packages/click-8.0.3-py3.10.egg/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/opt/homebrew/lib/python3.10/site-packages/click-8.0.3-py3.10.egg/click/decorators.py", line 38, in new_func
    return f(get_current_context().obj, *args, **kwargs)
  File "/Users/jgmize/src/habitica/habitica/cli.py", line 244, in status
    ('Mount', user.inventory.mount or '-'),
  File "/Users/jgmize/src/habitica/habitica/core/user.py", line 247, in mount
    return self.content.mountInfo(self._data['currentMount']) if self._data['currentMount'] else None
KeyError: 'currentMount'
```